### PR TITLE
hotfix module parameters update when using profiles

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -255,9 +255,6 @@ params {
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'
 
-// Load modules.config for DSL2 module specific options
-includeConfig 'conf/modules.config'
-
 profiles {
     debug {
         dumpHashes              = true
@@ -387,26 +384,16 @@ profiles {
     }
     infant {
         params.infant                           = true
-
         params.dwi_run_synthstrip               = true
-
         params.dwi_normalize_fa_mask_threshold  = 0.10
-
-        //params.fodf_max_fa_threshold            = 0.01
-        //params.fodf_min_md_threshold            = 0.00185
-
         params.frf_manual_frf                   = "12,5,5"
-
         params.run_pft_tracking                 = false
         params.local_min_len                    = 15
         params.local_fa_seeding_mask_threshold  = 0.10
-
         params.commit_para_diff                 = "1.2E-3"
         params.commit_iso_diff                  = "2.0E-3"
-
         params.decompose_min_len                = 10
         params.decompose_outlier_threshold      = 0.4
-
     }
     tracking {
         params.tracking         = true
@@ -418,6 +405,9 @@ profiles {
         params.freesurfer       = true
     }
 }
+
+// Load modules.config for DSL2 module specific options
+includeConfig 'conf/modules.config'
 
 // Load nf-core custom profiles from different Institutions
 includeConfig !System.getenv('NXF_OFFLINE') && params.custom_config_base ? "${params.custom_config_base}/nfcore_custom.config" : "/dev/null"


### PR DESCRIPTION
Using a profile (e.g. `-profile infant`) that contained specific parameters for specific modules did not overwrite the default value. Moving the `includeConfig` after the profile definition solved the issue. 