### PR TITLE
Fix logging error when no reverse image are provided

### DIFF
--- a/subworkflows/local/utils_nfcore_pediatric_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_pediatric_pipeline/main.nf
@@ -92,7 +92,7 @@ workflow PIPELINE_INITIALISATION {
                     if (!bvec) {
                         error("Please provide a bvec file for sample: ${meta.id}")
                     }
-                    if (!rev_b0) {
+                    if (!rev_b0 && !params.skip_dwi_preprocessing) {
                         error("Please provide a reverse phase encoded B0 image for sample: ${meta.id}")
                     }
                     if (!wmparc) {
@@ -151,7 +151,7 @@ workflow PIPELINE_INITIALISATION {
                     if (!bvec) {
                         error("Please provide a bvec file for sample: ${meta.id}")
                     }
-                    if (!rev_b0) {
+                    if (!rev_b0 && !params.skip_dwi_preprocessing) {
                         error("Please provide a reverse phase encoded B0 image for sample: ${meta.id}")
                     }
                     if (!wmparc) {
@@ -176,7 +176,7 @@ workflow PIPELINE_INITIALISATION {
                     if (!bvec) {
                         error("Please provide a bvec file for sample: ${meta.id}")
                     }
-                    if (!rev_b0) {
+                    if (!rev_b0 && !params.skip_dwi_preprocessing) {
                         error("Please provide a reverse phase encoded B0 image for sample: ${meta.id}")
                     }
                 }
@@ -232,7 +232,7 @@ workflow PIPELINE_INITIALISATION {
                     if (!bvec) {
                         error("Please provide a bvec file for sample: ${meta.id}")
                     }
-                    if (!rev_b0) {
+                    if (!rev_b0 && !params.skip_dwi_preprocessing) {
                         error("Please provide a reverse phase encoded B0 image for sample: ${meta.id}")
                     }
                     if (!labels) {
@@ -288,7 +288,7 @@ workflow PIPELINE_INITIALISATION {
                     if (!bvec) {
                         error("Please provide a bvec file for sample: ${meta.id}")
                     }
-                    if (!rev_b0) {
+                    if (!rev_b0 && !params.skip_dwi_preprocessing) {
                         error("Please provide a reverse phase encoded B0 image for sample: ${meta.id}")
                     }
                 }

--- a/tests/tracking.nf.test
+++ b/tests/tracking.nf.test
@@ -43,7 +43,7 @@ nextflow_pipeline {
         when {
             params {
 
-                params.input = "$projectDir/tests/data/samplesheet_testtracking.csv"
+                params.input = "$projectDir/tests/data/samplesheet_testtracking_norev.csv"
                 params.outdir = "$outputDir"
 
                 params.dti_shells = "0 1000"


### PR DESCRIPTION


<!--
# nf/pediatric pull request

Many thanks for contributing to nf/pediatric!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf/pediatric/tree/master/.github/CONTRIBUTING.md)
-->

When trying to run the pipeline with `--skip_dwi_preprocessing` without submitting a reverse b0 image, the subworkflow loading the data returned an error. Changed the assertion to omit if `--skip_dwi_preprocessing` is selected. Tests should catch it now. 

It will be removed when we switch to mandatory BIDS input.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/gagnonanthony/nf-pediatric/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
