### PR TITLE
Fix data type in `preproc/topup`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- Wrong data type for phillips scanners prior to topup.
 - Structural segmentation pipeline for infant data. (#3)
 - Correctly set `fastsurfer` version in docker container.
 

--- a/modules/nf-neuro/preproc/topup/main.nf
+++ b/modules/nf-neuro/preproc/topup/main.nf
@@ -39,7 +39,7 @@ process PREPROC_TOPUP {
 
     if [[ -f "$b0" ]];
     then
-        scil_volume_math.py concatenate $b0 $b0 ${prefix}__concatenated_b0.nii.gz
+        scil_volume_math.py concatenate $b0 $b0 ${prefix}__concatenated_b0.nii.gz --data_type float32
         scil_volume_math.py mean ${prefix}__concatenated_b0.nii.gz ${prefix}__b0_mean.nii.gz
     else
         scil_dwi_extract_b0.py $dwi $bval $bvec ${prefix}__b0_mean.nii.gz --mean --b0_threshold $b0_thr_extract_b0 --skip_b0_check
@@ -47,7 +47,7 @@ process PREPROC_TOPUP {
 
     if [[ -f "$rev_b0" ]];
     then
-        scil_volume_math.py concatenate $rev_b0 $rev_b0 ${prefix}__concatenated_rev_b0.nii.gz
+        scil_volume_math.py concatenate $rev_b0 $rev_b0 ${prefix}__concatenated_rev_b0.nii.gz --data_type float32
         scil_volume_math.py mean ${prefix}__concatenated_rev_b0.nii.gz ${prefix}__rev_b0_mean.nii.gz
     else
         scil_dwi_extract_b0.py $rev_dwi $rev_bval $rev_bvec ${prefix}__rev_b0_mean.nii.gz --mean --b0_threshold $b0_thr_extract_b0 --skip_b0_check

--- a/modules/nf-neuro/preproc/topup/preproc-topup.diff
+++ b/modules/nf-neuro/preproc/topup/preproc-topup.diff
@@ -1,5 +1,4 @@
 Changes in component 'nf-neuro/preproc/topup'
-'modules/nf-neuro/preproc/topup/environment.yml' is unchanged
 'modules/nf-neuro/preproc/topup/meta.yml' is unchanged
 Changes in 'preproc/topup/main.nf':
 --- modules/nf-neuro/preproc/topup/main.nf
@@ -21,8 +20,9 @@ Changes in 'preproc/topup/main.nf':
      output:
          tuple val(meta), path("*__corrected_b0s.nii.gz"), emit: topup_corrected_b0s
 
-'modules/nf-neuro/preproc/topup/tests/main.nf.test.snap' is unchanged
-'modules/nf-neuro/preproc/topup/tests/tags.yml' is unchanged
-'modules/nf-neuro/preproc/topup/tests/nextflow.config' is unchanged
+'modules/nf-neuro/preproc/topup/environment.yml' is unchanged
 'modules/nf-neuro/preproc/topup/tests/main.nf.test' is unchanged
+'modules/nf-neuro/preproc/topup/tests/nextflow.config' is unchanged
+'modules/nf-neuro/preproc/topup/tests/tags.yml' is unchanged
+'modules/nf-neuro/preproc/topup/tests/main.nf.test.snap' is unchanged
 ************************************************************


### PR DESCRIPTION
<!--
# nf/pediatric pull request

Many thanks for contributing to nf/pediatric!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf/pediatric/tree/master/.github/CONTRIBUTING.md)
-->

In case of acquisitions coming from a Phillips scanner, the data type needs to be specified prior to topup. Simply updating the module following https://github.com/scilus/nf-neuro/pull/91. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/gagnonanthony/nf-pediatric/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
