### PR TITLE
Fix resampling/reshaping issue and add publishing of `annot`/`stats` file in FS output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - [2025-03-03]
+
+### `Fixed`
+
+- Resampling/reshaping according to input file when registering brainnetome atlas ([#26](https://github.com/scilus/nf-pediatric/issues/26))
+
 ## [Unreleased] - [2025-02-28]
 
 ### `Added`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- Output `.annot` and `.stats` file for brainnetome in FS output ([#19](https://github.com/scilus/nf-pediatric/issues/19))
 - Resampling/reshaping according to input file when registering brainnetome atlas ([#26](https://github.com/scilus/nf-pediatric/issues/26))
 
 ## [Unreleased] - [2025-02-28]

--- a/conf/segmentation.config
+++ b/conf/segmentation.config
@@ -24,7 +24,7 @@ process {
                 saveAs: {
                     filename ->
                     def ses = meta.session ? "_${meta.session}" : ""
-                    if ( filename.contains("fastsurfer") ) { "${meta.id}${ses}' : ''}" }
+                    if ( filename.contains("fastsurfer") ) { "${meta.id}${ses}" }
                     else if ( filename.contains("versions.yml") ) { null }
                     else { params.lean_output ? null : filename }
                 }
@@ -261,25 +261,41 @@ process {
 
     withName: 'NF_PEDIATRIC:PEDIATRIC:SEGMENTATION:BRAINNETOMECHILD' {
         publishDir = [
-            path: { meta.session ? "${params.outdir}/${meta.id}/${meta.session}/anat/" : "${params.outdir}/${meta.id}/anat/" },
-            mode: params.publish_dir_mode,
-            saveAs: {
-                filename ->
-                def ses = meta.session ? "${meta.session}_" : ""
-                if ( filename.contains("child_v1.nii.gz") ) { "${meta.id}_${ses}seg-BrainnetomeChild_dseg.nii.gz" }
-                else if ( filename.contains("child_v1_dilated.nii.gz") ) {"${meta.id}_${ses}seg-BrainnetomeChild_dseg_dilated.nii.gz"}
-                else if ( filename.contains("subcortical.tsv") ) {"${meta.id}_${ses}seg-BrainnetomeChild_stat-subcortical.tsv"}
-                else if ( filename.contains("volume_lh") ) {"${meta.id}_${ses}seg-BrainnetomeChild_stat-lh_volume.tsv"}
-                else if ( filename.contains("volume_rh") ) {"${meta.id}_${ses}seg-BrainnetomeChild_stat-rh_volume.tsv"}
-                else if ( filename.contains("thickness_lh") ) {"${meta.id}_${ses}seg-BrainnetomeChild_stat-lh_thickness.tsv"}
-                else if ( filename.contains("thickness_rh") ) {"${meta.id}_${ses}seg-BrainnetomeChild_stat-rh_thickness.tsv"}
-                else if ( filename.contains("area_lh") ) {"${meta.id}_${ses}seg-BrainnetomeChild_stat-lh_area.tsv"}
-                else if ( filename.contains("area_rh") ) {"${meta.id}_${ses}seg-BrainnetomeChild_stat-rh_area.tsv"}
-                else if ( filename.contains("brainnetome_child_v1.txt") ) {"${meta.id}_${ses}seg-BrainnetomeChild_desc-labels.txt"}
-                else if ( filename.contains("brainnetome_child_v1.json") ) {"${meta.id}_${ses}seg-BrainnetomeChild_desc-labels.json"}
-                else if ( filename.contains("versions.yml") ) { null }
-                else { params.lean_output ? null : filename }
-            }
+            [
+                path: { meta.session ? "${params.outdir}/${meta.id}/${meta.session}/anat/" : "${params.outdir}/${meta.id}/anat/" },
+                mode: params.publish_dir_mode,
+                saveAs: {
+                    filename ->
+                    def ses = meta.session ? "${meta.session}_" : ""
+                    if ( filename.contains("child_v1.nii.gz") ) { "${meta.id}_${ses}seg-BrainnetomeChild_dseg.nii.gz" }
+                    else if ( filename.contains("child_v1_dilated.nii.gz") ) {"${meta.id}_${ses}seg-BrainnetomeChild_dseg_dilated.nii.gz"}
+                    else if ( filename.contains("subcortical.tsv") ) {"${meta.id}_${ses}seg-BrainnetomeChild_stat-subcortical.tsv"}
+                    else if ( filename.contains("volume_lh") ) {"${meta.id}_${ses}seg-BrainnetomeChild_stat-lh_volume.tsv"}
+                    else if ( filename.contains("volume_rh") ) {"${meta.id}_${ses}seg-BrainnetomeChild_stat-rh_volume.tsv"}
+                    else if ( filename.contains("thickness_lh") ) {"${meta.id}_${ses}seg-BrainnetomeChild_stat-lh_thickness.tsv"}
+                    else if ( filename.contains("thickness_rh") ) {"${meta.id}_${ses}seg-BrainnetomeChild_stat-rh_thickness.tsv"}
+                    else if ( filename.contains("area_lh") ) {"${meta.id}_${ses}seg-BrainnetomeChild_stat-lh_area.tsv"}
+                    else if ( filename.contains("area_rh") ) {"${meta.id}_${ses}seg-BrainnetomeChild_stat-rh_area.tsv"}
+                    else if ( filename.contains("brainnetome_child_v1.txt") ) {"${meta.id}_${ses}seg-BrainnetomeChild_desc-labels.txt"}
+                    else if ( filename.contains("brainnetome_child_v1.json") ) {"${meta.id}_${ses}seg-BrainnetomeChild_desc-labels.json"}
+                    else if ( filename.contains("versions.yml") ) { null }
+                    else { params.lean_output ? null : filename }
+                }
+            ],
+            [
+                path: {
+                    def ses = meta.session ? "_${meta.session}" : ""
+                    params.fs_output_dir ? "${params.fs_output_dir}/${meta.id}${ses}/${meta.id}/label/" : params.use_fastsurfer ? "${params.outdir}/../fastsurfer-v2.3.3/${meta.id}${ses}/${meta.id}/label/" : "${params.outdir}/../freesurfer-7.4.1/${meta.id}${ses}/${meta.id}/label/" },
+                mode: params.publish_dir_mode,
+                pattern: "*BN_Child.annot",
+            ],
+            [
+                path: {
+                    def ses = meta.session ? "_${meta.session}" : ""
+                    params.fs_output_dir ? "${params.fs_output_dir}/${meta.id}${ses}/${meta.id}/stats/" : params.use_fastsurfer ? "${params.outdir}/../fastsurfer-v2.3.3/${meta.id}${ses}/${meta.id}/stats/" : "${params.outdir}/../freesurfer-7.4.1/${meta.id}${ses}/${meta.id}/stats/" },
+                mode: params.publish_dir_mode,
+                pattern: "*BN_Child.stats"
+            ]
         ]
     }
 

--- a/modules/local/atlases/brainnetomechild.nf
+++ b/modules/local/atlases/brainnetomechild.nf
@@ -12,6 +12,8 @@ process ATLASES_BRAINNETOMECHILD {
     tuple val(meta), path("*brainnetome_child_v1_dilated.nii.gz")       , emit: labels_dilate
     tuple val(meta), path("*[brainnetome_child]*.txt")                  , emit: labels_txt
     tuple val(meta), path("*[brainnetome_child]*.json")                 , emit: labels_json
+    tuple val(meta), path("*BN_Child.stats")                            , emit: stats_files
+    tuple val(meta), path("*BN_Child.annot")                            , emit: annot_files
     path("*.tsv")                                                       , emit: stats
     path "versions.yml"                                                 , emit: versions
 
@@ -190,6 +192,10 @@ process ATLASES_BRAINNETOMECHILD {
     cp Brainnetome_Child/* ./
     rm ${folder}/fsaverage
 
+    # Fetch .annot files and .stats files, to place within the FastSurfer/FreeSurfer folder.
+    cp \${FS_ID_FOLDER}/label/*BN_Child.annot ./
+    cp \${FS_ID_FOLDER}/stats/*BN_Child.stats ./
+
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         scilpy: \$(pip list | grep scilpy | tr -s ' ' | cut -d' ' -f2)
@@ -212,6 +218,10 @@ process ATLASES_BRAINNETOMECHILD {
     touch ${prefix}__area_rh.BN_Child.tsv
     touch ${prefix}__thickness_lh.BN_Child.tsv
     touch ${prefix}__thickness_rh.BN_Child.tsv
+    touch lh.BN_Child.annot
+    touch rh.BN_Child.annot
+    touch lh.BN_Child.stats
+    touch rh.BN_Child.stats
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/atlases/brainnetomechild.nf
+++ b/modules/local/atlases/brainnetomechild.nf
@@ -158,7 +158,7 @@ process ATLASES_BRAINNETOMECHILD {
     # Since Freesurfer is all in 1x1x1mm and a 256x256x256 array, our atlases must be resampled/reshaped
     echo -e "\${BLUE}Reshape as the original input and convert the final atlases into uint16\${NC}"
     mri_convert \${FS_ID_FOLDER}/mri/rawavg.mgz \${FS_ID_FOLDER}/mri/rawavg.nii.gz
-    scil_reshape_to_reference.py BN_child_atlas/atlas_brainnetome_child.nii.gz \${FS_ID_FOLDER}/mri/rawavg.nii.gz \${FS_ID_FOLDER}/atlas_brainnetome_child.nii.gz --interpolation nearest
+    scil_reshape_to_reference.py BN_child_atlas/atlas_brainnetome_child.nii.gz \${FS_ID_FOLDER}/mri/rawavg.nii.gz BN_child_atlas/atlas_brainnetome_child.nii.gz --interpolation nearest -f
 
     # ==================================================================================
     # Safer for most script, thats our label data type

--- a/modules/nf-neuro/segmentation/fastsurfer/main.nf
+++ b/modules/nf-neuro/segmentation/fastsurfer/main.nf
@@ -61,7 +61,14 @@ process SEGMENTATION_FASTSURFER {
     def FASTSURFER_HOME = "/fastsurfer"
 
     """
-    mkdir ${prefix}__fastsurfer/
+    mkdir -p ${prefix}__fastsurfer/${prefix}/mri/transforms \
+        ${prefix}__fastsurfer/${prefix}/label/ \
+        ${prefix}__fastsurfer/${prefix}/surf/ \
+        ${prefix}__fastsurfer/${prefix}/stats/ \
+        ${prefix}__fastsurfer/${prefix}/scripts/ \
+        ${prefix}__fastsurfer/${prefix}/tmp/ \
+        ${prefix}__fastsurfer/${prefix}/touch/
+
     touch ${prefix}__final_t1.nii.gz
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/nf-neuro/segmentation/fsreconall/main.nf
+++ b/modules/nf-neuro/segmentation/fsreconall/main.nf
@@ -63,7 +63,13 @@ process SEGMENTATION_FSRECONALL {
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    mkdir ${prefix}__recon_all
+    mkdir -p ${prefix}__recon_all/${prefix}/mri/transforms \
+        ${prefix}__recon_all/${prefix}/label/ \
+        ${prefix}__recon_all/${prefix}/surf/ \
+        ${prefix}__recon_all/${prefix}/stats/ \
+        ${prefix}__recon_all/${prefix}/scripts/ \
+        ${prefix}__recon_all/${prefix}/tmp/ \
+        ${prefix}__recon_all/${prefix}/touch/
     touch ${prefix}__final_t1.nii.gz
 
     cat <<-END_VERSIONS > versions.yml

--- a/tests/chained.nf.test.snap
+++ b/tests/chained.nf.test.snap
@@ -188,14 +188,27 @@
             ],
             [
                 "",
-                "sub-test' : ''}"
+                "sub-test",
+                "sub-test/sub-test",
+                "sub-test/sub-test/label",
+                "sub-test/sub-test/label/lh.BN_Child.annot",
+                "sub-test/sub-test/label/rh.BN_Child.annot",
+                "sub-test/sub-test/mri",
+                "sub-test/sub-test/mri/transforms",
+                "sub-test/sub-test/scripts",
+                "sub-test/sub-test/stats",
+                "sub-test/sub-test/stats/lh.BN_Child.stats",
+                "sub-test/sub-test/stats/rh.BN_Child.stats",
+                "sub-test/sub-test/surf",
+                "sub-test/sub-test/tmp",
+                "sub-test/sub-test/touch"
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "24.10.3"
         },
-        "timestamp": "2025-02-28T09:50:07.593117"
+        "timestamp": "2025-03-03T14:20:39.793993"
     },
     "Connectomics + tracking + segmentation + infant profiles - should run successfully": {
         "content": [
@@ -482,14 +495,27 @@
             ],
             [
                 "",
-                "sub-test' : ''}"
+                "sub-test",
+                "sub-test/sub-test",
+                "sub-test/sub-test/label",
+                "sub-test/sub-test/label/lh.BN_Child.annot",
+                "sub-test/sub-test/label/rh.BN_Child.annot",
+                "sub-test/sub-test/mri",
+                "sub-test/sub-test/mri/transforms",
+                "sub-test/sub-test/scripts",
+                "sub-test/sub-test/stats",
+                "sub-test/sub-test/stats/lh.BN_Child.stats",
+                "sub-test/sub-test/stats/rh.BN_Child.stats",
+                "sub-test/sub-test/surf",
+                "sub-test/sub-test/tmp",
+                "sub-test/sub-test/touch"
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "24.10.3"
         },
-        "timestamp": "2025-02-14T09:56:30.766871"
+        "timestamp": "2025-03-03T14:16:15.911625"
     },
     "Connectomics + tracking profiles - should run successfully": {
         "content": [

--- a/tests/freesurfer.nf.test.snap
+++ b/tests/freesurfer.nf.test.snap
@@ -47,14 +47,27 @@
             ],
             [
                 "",
-                "sub-test"
+                "sub-test",
+                "sub-test/sub-test",
+                "sub-test/sub-test/label",
+                "sub-test/sub-test/label/lh.BN_Child.annot",
+                "sub-test/sub-test/label/rh.BN_Child.annot",
+                "sub-test/sub-test/mri",
+                "sub-test/sub-test/mri/transforms",
+                "sub-test/sub-test/scripts",
+                "sub-test/sub-test/stats",
+                "sub-test/sub-test/stats/lh.BN_Child.stats",
+                "sub-test/sub-test/stats/rh.BN_Child.stats",
+                "sub-test/sub-test/surf",
+                "sub-test/sub-test/tmp",
+                "sub-test/sub-test/touch"
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "24.10.3"
         },
-        "timestamp": "2025-02-11T09:04:48.720014"
+        "timestamp": "2025-03-03T14:23:46.221465"
     },
     "Segmentation profile - fastsurfer - should run successfully": {
         "content": [
@@ -104,13 +117,26 @@
             ],
             [
                 "",
-                "sub-test' : ''}"
+                "sub-test",
+                "sub-test/sub-test",
+                "sub-test/sub-test/label",
+                "sub-test/sub-test/label/lh.BN_Child.annot",
+                "sub-test/sub-test/label/rh.BN_Child.annot",
+                "sub-test/sub-test/mri",
+                "sub-test/sub-test/mri/transforms",
+                "sub-test/sub-test/scripts",
+                "sub-test/sub-test/stats",
+                "sub-test/sub-test/stats/lh.BN_Child.stats",
+                "sub-test/sub-test/stats/rh.BN_Child.stats",
+                "sub-test/sub-test/surf",
+                "sub-test/sub-test/tmp",
+                "sub-test/sub-test/touch"
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "24.10.3"
         },
-        "timestamp": "2025-02-11T09:05:19.550467"
+        "timestamp": "2025-03-03T14:13:37.319191"
     }
 }

--- a/tests/multisubjects.nf.test.snap
+++ b/tests/multisubjects.nf.test.snap
@@ -559,14 +559,40 @@
             ],
             [
                 "",
-                "sub-test1' : ''}",
-                "sub-test2_ses-baseline' : ''}"
+                "sub-test1",
+                "sub-test1/sub-test1",
+                "sub-test1/sub-test1/label",
+                "sub-test1/sub-test1/label/lh.BN_Child.annot",
+                "sub-test1/sub-test1/label/rh.BN_Child.annot",
+                "sub-test1/sub-test1/mri",
+                "sub-test1/sub-test1/mri/transforms",
+                "sub-test1/sub-test1/scripts",
+                "sub-test1/sub-test1/stats",
+                "sub-test1/sub-test1/stats/lh.BN_Child.stats",
+                "sub-test1/sub-test1/stats/rh.BN_Child.stats",
+                "sub-test1/sub-test1/surf",
+                "sub-test1/sub-test1/tmp",
+                "sub-test1/sub-test1/touch",
+                "sub-test2_ses-baseline",
+                "sub-test2_ses-baseline/sub-test2",
+                "sub-test2_ses-baseline/sub-test2/label",
+                "sub-test2_ses-baseline/sub-test2/label/lh.BN_Child.annot",
+                "sub-test2_ses-baseline/sub-test2/label/rh.BN_Child.annot",
+                "sub-test2_ses-baseline/sub-test2/mri",
+                "sub-test2_ses-baseline/sub-test2/mri/transforms",
+                "sub-test2_ses-baseline/sub-test2/scripts",
+                "sub-test2_ses-baseline/sub-test2/stats",
+                "sub-test2_ses-baseline/sub-test2/stats/lh.BN_Child.stats",
+                "sub-test2_ses-baseline/sub-test2/stats/rh.BN_Child.stats",
+                "sub-test2_ses-baseline/sub-test2/surf",
+                "sub-test2_ses-baseline/sub-test2/tmp",
+                "sub-test2_ses-baseline/sub-test2/touch"
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "24.10.3"
         },
-        "timestamp": "2025-02-28T09:58:59.024441"
+        "timestamp": "2025-03-03T14:27:20.626009"
     }
 }


### PR DESCRIPTION
<!--
# nf-pediatric pull request

Many thanks for contributing to nf-pediatric!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/scilus/nf-pediatric/tree/master/.github/CONTRIBUTING.md)
-->

Solves the issue surrounding reshaping/resampling. I opted to keep this specific step, and nothing will change if the input has the same shape. `.annot` and `.stats` files generated in the brainnetome atlas mapping are now outputted and published within the FS folder. Closes #26 and #19 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/scilus/nf-pediatric/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
