### PR TITLE
FIX: Glob pattern for matching diffusion related files in output template space subworkflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-beta] - [2025-08-13]
+
+### `Fixed`
+
+- Overwriting of output FA file by template maps due to a non-strict enough glob pattern when warping into a template space.
+
 ## [0.1.0-alpha] - [2025-08-06]
 
 ### `Added`

--- a/conf/template.config
+++ b/conf/template.config
@@ -115,17 +115,16 @@ process {
                     filename ->
                     def ses = meta.session ? "${meta.session}_" : ""
                     if ( filename.contains("ad") ) { "${meta.id}_${ses}space-${params.template}_desc-ad.nii.gz" }
-                    else if ( filename.contains("fa") ) { "${meta.id}_${ses}space-${params.template}_desc-fa.nii.gz" }
-                    else if ( filename.contains("rd") ) { "${meta.id}_${ses}space-${params.template}_desc-rd.nii.gz" }
-                    else if ( filename.contains("md") ) { "${meta.id}_${ses}space-${params.template}_desc-md.nii.gz" }
-                    else if ( filename.contains("mode") ) { "${meta.id}_${ses}space-${params.template}_desc-mode.nii.gz" }
-                    else if ( filename.contains("tensor") ) { "${meta.id}_${ses}space-${params.template}_desc-tensor.nii.gz" }
-                    else if ( filename.contains("rgb") ) { "${meta.id}_${ses}space-${params.template}_desc-rgb.nii.gz" }
-                    else if ( filename.contains("ga") ) { "${meta.id}_${ses}space-${params.template}_desc-ga.nii.gz" }
-                    else if ( filename.contains("afd_total") ) { "${meta.id}_${ses}space-${params.template}_desc-afd_total.nii.gz" }
-                    else if ( filename.contains("nufo") ) { "${meta.id}_${ses}space-${params.template}_desc-nufo.nii.gz" }
-                    else if ( filename.contains("afd_max") ) { "${meta.id}_${ses}space-${params.template}_desc-afd_max.nii.gz" }
-                    else if ( filename.contains("afd_sum") ) { "${meta.id}_${ses}space-${params.template}_desc-afd_sum.nii.gz" }
+                    else if ( filename.contains("_fa_") ) { "${meta.id}_${ses}space-${params.template}_desc-fa.nii.gz" }
+                    else if ( filename.contains("_rd_") ) { "${meta.id}_${ses}space-${params.template}_desc-rd.nii.gz" }
+                    else if ( filename.contains("_md_") ) { "${meta.id}_${ses}space-${params.template}_desc-md.nii.gz" }
+                    else if ( filename.contains("_mode_") ) { "${meta.id}_${ses}space-${params.template}_desc-mode.nii.gz" }
+                    else if ( filename.contains("_rgb_") ) { "${meta.id}_${ses}space-${params.template}_desc-rgb.nii.gz" }
+                    else if ( filename.contains("_ga_") ) { "${meta.id}_${ses}space-${params.template}_desc-ga.nii.gz" }
+                    else if ( filename.contains("_afd_total_") ) { "${meta.id}_${ses}space-${params.template}_desc-afd_total.nii.gz" }
+                    else if ( filename.contains("_nufo_") ) { "${meta.id}_${ses}space-${params.template}_desc-nufo.nii.gz" }
+                    else if ( filename.contains("_afd_max_") ) { "${meta.id}_${ses}space-${params.template}_desc-afd_max.nii.gz" }
+                    else if ( filename.contains("_afd_sum_") ) { "${meta.id}_${ses}space-${params.template}_desc-afd_sum.nii.gz" }
                     else if ( filename.contains("versions.yml") ) { null }
                     else { params.lean_output ? null : filename }
                 }


### PR DESCRIPTION
…emplate space

<!--
# scilus/nf-pediatric pull request

Many thanks for contributing to scilus/nf-pediatric!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/scilus/nf-pediatric/tree/master/.github/CONTRIBUTING.md)
-->

There was an issue during warping in template space, where for participants using templates (< 2 years), the final outputted FA map was overwritten by the template WM map due to a non-strict enough glob pattern. This PR fixes it.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/scilus/nf-pediatric/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x]  Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
