### PR TITLE
FIX: RGB FA map registration in template space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- Fix RGB FA registration to template space.
 - Add filtering step removing null values for anatomical coregistration in case of missing files.
 - Fix precedence issues in branching logic for anatomical to diffusion space registration ([#63](https://github.com/scilus/nf-pediatric/issues/63))
 - Handling of B0 threshold in `preproc/n4` and `preproc/normalize` ([[#58](https://github.com/scilus/nf-pediatric/issues/58)])

--- a/conf/template.config
+++ b/conf/template.config
@@ -75,7 +75,7 @@ process {
                 filename ->
                 def ses = meta.session ? "${meta.session}_" : ""
                 def mod = (meta.age < 2.5 || meta.age > 18) ? "T2w" : "T1w"
-                if ( filename.contains("_warped.nii.gz") ) { "${meta.id}_${ses}space-${params.template}_desc-preproc_${mod}.nii.gz" }
+                if ( filename.contains("warped.nii.gz") ) { "${meta.id}_${ses}space-${params.template}_desc-preproc_${mod}.nii.gz" }
                 else if ( filename.contains("0Warp.nii.gz") ) { "${meta.id}_${ses}from-dwi_to-${params.template}_warp.nii.gz" }
                 else if ( filename.contains("1GenericAffine.mat") ) { "${meta.id}_${ses}from-dwi_to-${params.template}_affine.mat" }
                 else if ( filename.contains("1InverseWarp.nii.gz") ) { "${meta.id}_${ses}from-${params.template}_to-dwi_warp.nii.gz" }
@@ -119,12 +119,31 @@ process {
                     else if ( filename.contains("_rd_") ) { "${meta.id}_${ses}space-${params.template}_desc-rd.nii.gz" }
                     else if ( filename.contains("_md_") ) { "${meta.id}_${ses}space-${params.template}_desc-md.nii.gz" }
                     else if ( filename.contains("_mode_") ) { "${meta.id}_${ses}space-${params.template}_desc-mode.nii.gz" }
-                    else if ( filename.contains("_rgb_") ) { "${meta.id}_${ses}space-${params.template}_desc-rgb.nii.gz" }
                     else if ( filename.contains("_ga_") ) { "${meta.id}_${ses}space-${params.template}_desc-ga.nii.gz" }
                     else if ( filename.contains("_afd_total_") ) { "${meta.id}_${ses}space-${params.template}_desc-afd_total.nii.gz" }
                     else if ( filename.contains("_nufo_") ) { "${meta.id}_${ses}space-${params.template}_desc-nufo.nii.gz" }
                     else if ( filename.contains("_afd_max_") ) { "${meta.id}_${ses}space-${params.template}_desc-afd_max.nii.gz" }
                     else if ( filename.contains("_afd_sum_") ) { "${meta.id}_${ses}space-${params.template}_desc-afd_sum.nii.gz" }
+                    else if ( filename.contains("versions.yml") ) { null }
+                    else { params.lean_output ? null : filename }
+                }
+            ]
+        ]
+    }
+    withName: 'NF_PEDIATRIC:PEDIATRIC:OUTPUT_TEMPLATE_SPACE:WARPRGB' {
+        ext.interpolation = 'Linear'
+        ext.dimensionality = 3
+        ext.image_type = 3
+        ext.output_dtype = "uchar"
+        ext.default_val = 0
+        publishDir = [
+            [
+                path: { meta.session ? "${params.outdir}/${meta.id}/${meta.session}/dwi/" : "${params.outdir}/${meta.id}/dwi/" },
+                mode: params.publish_dir_mode,
+                saveAs: {
+                    filename ->
+                    def ses = meta.session ? "${meta.session}_" : ""
+                    if ( filename.contains("_rgb_") ) { "${meta.id}_${ses}space-${params.template}_desc-rgb.nii.gz" }
                     else if ( filename.contains("versions.yml") ) { null }
                     else { params.lean_output ? null : filename }
                 }

--- a/subworkflows/nf-neuro/output_template_space/output_template_space.diff
+++ b/subworkflows/nf-neuro/output_template_space/output_template_space.diff
@@ -3,7 +3,47 @@ Changes in component 'nf-neuro/output_template_space'
 Changes in 'output_template_space/main.nf':
 --- subworkflows/nf-neuro/output_template_space/main.nf
 +++ subworkflows/nf-neuro/output_template_space/main.nf
-@@ -193,4 +193,3 @@
+@@ -5,6 +5,7 @@
+ include { BETCROP_FSLBETCROP as BET_T2W                 } from '../../../modules/nf-neuro/betcrop/fslbetcrop/main.nf'
+ include { REGISTRATION_ANTS                             } from '../../../modules/nf-neuro/registration/ants/main.nf'
+ include { REGISTRATION_ANTSAPPLYTRANSFORMS as WARPIMAGES} from '../../../modules/nf-neuro/registration/antsapplytransforms/main.nf'
++include { REGISTRATION_ANTSAPPLYTRANSFORMS as WARPRGB   } from '../../../modules/nf-neuro/registration/antsapplytransforms/main.nf'
+ include { REGISTRATION_ANTSAPPLYTRANSFORMS as WARPMASK  } from '../../../modules/nf-neuro/registration/antsapplytransforms/main.nf'
+ include { REGISTRATION_ANTSAPPLYTRANSFORMS as WARPLABELS} from '../../../modules/nf-neuro/registration/antsapplytransforms/main.nf'
+ include { REGISTRATION_TRACTOGRAM                       } from '../../../modules/nf-neuro/registration/tractogram/main.nf'
+@@ -14,6 +15,7 @@
+     take:
+         ch_anat                     // channel: [ val(meta), [ anat ] ]
+         ch_nifti_files              // channel: [ val(meta), [ nifti_files ] ]
++        ch_rgb_files                // channel: [ val(meta), [ rgb_files ] ]
+         ch_mask_files               // channel: [ val(meta), [ mask_files ] ]
+         ch_labels_files             // channel: [ val(meta), [ labels_files ] ]
+         ch_trk_files                // channel: [ val(meta), [ trk_files ] ]
+@@ -151,9 +153,16 @@
+         | join(REGISTRATION_ANTS.out.image)
+         | join(REGISTRATION_ANTS.out.warp)
+         | join(REGISTRATION_ANTS.out.affine)
+-
+     WARPIMAGES ( ch_files_to_transform )
+     ch_versions = ch_versions.mix(WARPIMAGES.out.versions)
++
++    // ** Same process for the rgb files ** //
++    ch_rgb_to_transform = ch_rgb_files
++        | join(REGISTRATION_ANTS.out.image)
++        | join(REGISTRATION_ANTS.out.warp)
++        | join(REGISTRATION_ANTS.out.affine)
++    WARPRGB ( ch_rgb_to_transform )
++    ch_versions = ch_versions.mix(WARPRGB.out.versions)
+ 
+     // ** Same process for the masks ** //
+     ch_masks_to_transform = ch_mask_files
+@@ -188,9 +197,9 @@
+         ch_t2w_tpl                  = ch_t2w_tpl                                        // channel: [ tpl-T2w ]
+         ch_registered_anat          = REGISTRATION_ANTS.out.image                       // channel: [ val(meta), [ image ] ]
+         ch_warped_nifti_files       = WARPIMAGES.out.warped_image                       // channel: [ val(meta), [ warped_image ] ]
++        ch_rgb_nifti_files          = WARPRGB.out.warped_image                          // channel: [ val(meta), [ warped_rgb ] ]
+         ch_warped_mask_files        = WARPMASK.out.warped_image                         // channel: [ val(meta), [ warped_mask ] ]
+         ch_warped_labels_files      = WARPLABELS.out.warped_image                       // channel: [ val(meta), [ warped_labels ] ]
          ch_warped_trk_files         = REGISTRATION_TRACTOGRAM.out.warped_tractogram     // channel: [ val(meta), [ warped_tractogram ] ]
          versions                    = ch_versions                                       // channel: [ versions.yml ]
  }

--- a/tests/chained.nf.test.snap
+++ b/tests/chained.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "Connectomics + tracking + segmentation profiles - should run successfully": {
         "content": [
-            225,
+            229,
             {
                 "ANATTODWI": {
                     "ants": "2.4.3",
@@ -182,6 +182,11 @@
                     "mrtrix": "3.0.4",
                     "imagemagick": null
                 },
+                "WARPRGB": {
+                    "ants": "2.4.3",
+                    "mrtrix": "3.0.4",
+                    "imagemagick": null
+                },
                 "Workflow": {
                     "scilus/nf-pediatric": "v0.1.0-beta"
                 }
@@ -254,6 +259,8 @@
                 "sub-test1/ses-baseline/anat/sub-test1_ses-baseline_space-DWI_label-WM_probseg.nii.gz",
                 "sub-test1/ses-baseline/anat/sub-test1_ses-baseline_space-DWI_seg-DK_dseg.json",
                 "sub-test1/ses-baseline/anat/sub-test1_ses-baseline_space-DWI_seg-DK_dseg.nii.gz",
+                "sub-test1/ses-baseline/anat/sub-test1_ses-baseline_space-MNIInfant_desc-preproc_T2w.json",
+                "sub-test1/ses-baseline/anat/sub-test1_ses-baseline_space-MNIInfant_desc-preproc_T2w.nii.gz",
                 "sub-test1/ses-baseline/anat/sub-test1_ses-baseline_space-MNIInfant_label-CSF_mask.json",
                 "sub-test1/ses-baseline/anat/sub-test1_ses-baseline_space-MNIInfant_label-CSF_mask.nii.gz",
                 "sub-test1/ses-baseline/anat/sub-test1_ses-baseline_space-MNIInfant_label-CSF_probseg.json",
@@ -431,6 +438,8 @@
                 "sub-test1/ses-time1/anat/sub-test1_ses-time1_space-DWI_label-WM_probseg.nii.gz",
                 "sub-test1/ses-time1/anat/sub-test1_ses-time1_space-DWI_seg-BrainnetomeChild_dseg.json",
                 "sub-test1/ses-time1/anat/sub-test1_ses-time1_space-DWI_seg-BrainnetomeChild_dseg.nii.gz",
+                "sub-test1/ses-time1/anat/sub-test1_ses-time1_space-MNIInfant_desc-preproc_T1w.json",
+                "sub-test1/ses-time1/anat/sub-test1_ses-time1_space-MNIInfant_desc-preproc_T1w.nii.gz",
                 "sub-test1/ses-time1/anat/sub-test1_ses-time1_space-MNIInfant_label-CSF_mask.json",
                 "sub-test1/ses-time1/anat/sub-test1_ses-time1_space-MNIInfant_label-CSF_mask.nii.gz",
                 "sub-test1/ses-time1/anat/sub-test1_ses-time1_space-MNIInfant_label-CSF_probseg.json",
@@ -604,6 +613,8 @@
                 "sub-test2/anat/sub-test2_space-DWI_label-WM_probseg.nii.gz",
                 "sub-test2/anat/sub-test2_space-DWI_seg-BrainnetomeChild_dseg.json",
                 "sub-test2/anat/sub-test2_space-DWI_seg-BrainnetomeChild_dseg.nii.gz",
+                "sub-test2/anat/sub-test2_space-MNIInfant_desc-preproc_T2w.json",
+                "sub-test2/anat/sub-test2_space-MNIInfant_desc-preproc_T2w.nii.gz",
                 "sub-test2/anat/sub-test2_space-MNIInfant_label-CSF_mask.json",
                 "sub-test2/anat/sub-test2_space-MNIInfant_label-CSF_mask.nii.gz",
                 "sub-test2/anat/sub-test2_space-MNIInfant_label-CSF_probseg.json",
@@ -775,6 +786,8 @@
                 "sub-test3/anat/sub-test3_space-DWI_label-WM_probseg.nii.gz",
                 "sub-test3/anat/sub-test3_space-DWI_seg-BrainnetomeChild_dseg.json",
                 "sub-test3/anat/sub-test3_space-DWI_seg-BrainnetomeChild_dseg.nii.gz",
+                "sub-test3/anat/sub-test3_space-MNIInfant_desc-preproc_T2w.json",
+                "sub-test3/anat/sub-test3_space-MNIInfant_desc-preproc_T2w.nii.gz",
                 "sub-test3/anat/sub-test3_space-MNIInfant_label-CSF_mask.json",
                 "sub-test3/anat/sub-test3_space-MNIInfant_label-CSF_mask.nii.gz",
                 "sub-test3/anat/sub-test3_space-MNIInfant_label-CSF_probseg.json",
@@ -956,9 +969,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.2"
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2025-08-06T12:37:05.22776"
+        "timestamp": "2025-09-02T21:26:10.667372"
     },
     "Bundling + tracking profiles - should run successfully": {
         "content": [

--- a/workflows/pediatric.nf
+++ b/workflows/pediatric.nf
@@ -845,7 +845,7 @@ workflow PEDIATRIC {
                 def all_files = file_lists.flatten().findAll { it != null }
                 return tuple(meta, all_files)
             }
-        
+
         ch_rgb_files_to_transform = ch_rgb_files_to_transform
             .groupTuple()
             .map { tuple_elements ->

--- a/workflows/pediatric.nf
+++ b/workflows/pediatric.nf
@@ -87,6 +87,7 @@ workflow PEDIATRIC {
     ch_versions = Channel.empty()
     ch_multiqc_files_sub = Channel.empty()
     ch_nifti_files_to_transform = Channel.empty()
+    ch_rgb_files_to_transform = Channel.empty()
     ch_mask_files_to_transform = Channel.empty()
     ch_labels_files_to_transform = Channel.empty()
     ch_trk_files_to_transform = Channel.empty()
@@ -300,6 +301,7 @@ workflow PEDIATRIC {
             .mix(RECONST_DTIMETRICS.out.rd)
             .mix(RECONST_DTIMETRICS.out.ga)
             .mix(RECONST_DTIMETRICS.out.mode)
+        ch_rgb_files_to_transform = ch_rgb_files_to_transform
             .mix(RECONST_DTIMETRICS.out.rgb)
 
         //
@@ -843,6 +845,15 @@ workflow PEDIATRIC {
                 def all_files = file_lists.flatten().findAll { it != null }
                 return tuple(meta, all_files)
             }
+        
+        ch_rgb_files_to_transform = ch_rgb_files_to_transform
+            .groupTuple()
+            .map { tuple_elements ->
+                def meta = tuple_elements[0]
+                def file_lists = tuple_elements[1..-1] // Get all elements except the first (meta)
+                def all_files = file_lists.flatten().findAll { it != null }
+                return tuple(meta, all_files)
+            }
 
         ch_mask_files_to_transform = ch_mask_files_to_transform
             .groupTuple()
@@ -874,6 +885,7 @@ workflow PEDIATRIC {
         OUTPUT_TEMPLATE_SPACE(
             ANATTODWI.out.t1_warped,
             ch_nifti_files_to_transform,
+            ch_rgb_files_to_transform,
             ch_mask_files_to_transform,
             ch_labels_files_to_transform,
             ch_trk_files_to_transform


### PR DESCRIPTION
<!--
# scilus/nf-pediatric pull request

Many thanks for contributing to scilus/nf-pediatric!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/scilus/nf-pediatric/tree/master/.github/CONTRIBUTING.md)
-->

RGB FA map were not properly registered in template space (results were squeezed in 3D and not in the right datatype). This PR adds a new process in the `output_template_space` subworkflow to precisely warp RGB FA. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/scilus/nf-pediatric/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
