### PR TITLE
FIX: Dynamic resource allocation based on input filesize for tractogram registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- Add dynamic resource allocation for registering tractograms in output space ([#56](https://github.com/scilus/nf-pediatric/issues/56))
 - Fix RGB FA registration to template space.
 - Add filtering step removing null values for anatomical coregistration in case of missing files.
 - Fix precedence issues in branching logic for anatomical to diffusion space registration ([#63](https://github.com/scilus/nf-pediatric/issues/63))

--- a/conf/base.config
+++ b/conf/base.config
@@ -55,6 +55,15 @@ process {
         memory = { 16.GB * task.attempt * (executor.name == 'slurm' ? 2 : 1)    }
         time   = { 8.h   * task.attempt * (executor.name == 'slurm' ? 2 : 1)    }
     }
+    withLabel:process_dynamic {
+        cpus   = { 1 * task.attempt * (executor.name == 'slurm' ? 2 : 1)        }
+        time   = { 4.h  * task.attempt * (executor.name == 'slurm' ? 2 : 1)     }
+        memory = {
+            def input_size = task.inputFiles.collect { it.size() }.sum()
+            def base_mem = 4.GB.toBytes()
+            return (base_mem + input_size * 2.0).bytes
+        }
+    }
     withLabel:error_ignore {
         errorStrategy = 'ignore'
     }

--- a/conf/base.config
+++ b/conf/base.config
@@ -58,11 +58,6 @@ process {
     withLabel:process_dynamic {
         cpus   = { 1 * task.attempt * (executor.name == 'slurm' ? 2 : 1)        }
         time   = { 4.h  * task.attempt * (executor.name == 'slurm' ? 2 : 1)     }
-        memory = {
-            def input_size = task.inputFiles.collect { it.size() }.sum()
-            def base_mem = 4.GB.toBytes()
-            return (base_mem + input_size * 2.0).bytes
-        }
     }
     withLabel:error_ignore {
         errorStrategy = 'ignore'

--- a/modules/nf-neuro/registration/tractogram/main.nf
+++ b/modules/nf-neuro/registration/tractogram/main.nf
@@ -1,6 +1,6 @@
 process REGISTRATION_TRACTOGRAM {
     tag "$meta.id"
-    label 'process_single'
+    label 'process_dynamic'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://scil.usherbrooke.ca/containers/scilus_2.0.2.sif':

--- a/modules/nf-neuro/registration/tractogram/main.nf
+++ b/modules/nf-neuro/registration/tractogram/main.nf
@@ -1,6 +1,7 @@
 process REGISTRATION_TRACTOGRAM {
     tag "$meta.id"
     label 'process_dynamic'
+    memory { "${meta.mem} B" }
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://scil.usherbrooke.ca/containers/scilus_2.0.2.sif':

--- a/modules/nf-neuro/registration/tractogram/registration-tractogram.diff
+++ b/modules/nf-neuro/registration/tractogram/registration-tractogram.diff
@@ -4,7 +4,16 @@ Changes in component 'nf-neuro/registration/tractogram'
 Changes in 'registration/tractogram/main.nf':
 --- modules/nf-neuro/registration/tractogram/main.nf
 +++ modules/nf-neuro/registration/tractogram/main.nf
-@@ -10,7 +10,7 @@
+@@ -1,6 +1,7 @@
+ process REGISTRATION_TRACTOGRAM {
+     tag "$meta.id"
+-    label 'process_single'
++    label 'process_dynamic'
++    memory { "${meta.mem} B" }
+ 
+     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+         'https://scil.usherbrooke.ca/containers/scilus_2.0.2.sif':
+@@ -10,7 +11,7 @@
      tuple val(meta), path(anat), path(transfo), path(tractogram), path(ref) /* optional, value = [] */, path(deformation) /* optional, value = [] */
  
      output:
@@ -13,16 +22,17 @@ Changes in 'registration/tractogram/main.nf':
      path "versions.yml"           , emit: versions
  
      when:
-@@ -38,23 +38,31 @@
+@@ -38,23 +39,33 @@
          ext=\${tractogram#*.}
          bname=\$(basename \${tractogram} .\${ext})
  
 -        scil_tractogram_apply_transform.py \$tractogram $anat $transfo tmp.trk\
-+        if [[ \$ext -eq "h5" ]]; then
++        if [[ \$ext == "h5" ]]; then
 +            scil_tractogram_apply_transform_to_hdf5.py \$tractogram $anat $transfo \
 +                        ${prefix}__\${bname}${suffix}.\${ext} \
                          $in_deformation\
                          $inverse\
++                        $cut_invalid\
                          $reverse_operation\
                          $force\
                          $reference
@@ -30,6 +40,7 @@ Changes in 'registration/tractogram/main.nf':
 +            scil_tractogram_apply_transform.py \$tractogram $anat $transfo tmp.trk\
 +                            $in_deformation\
 +                            $inverse\
++                            $cut_invalid\
 +                            $reverse_operation\
 +                            $force\
 +                            $reference

--- a/subworkflows/nf-neuro/output_template_space/main.nf
+++ b/subworkflows/nf-neuro/output_template_space/main.nf
@@ -186,7 +186,13 @@ workflow OUTPUT_TEMPLATE_SPACE {
         | join(REGISTRATION_ANTS.out.inverse_warp)
         | join(REGISTRATION_ANTS.out.affine)
         | map{ meta, trk, image, warp, affine ->
-            tuple(meta, image, affine, trk, [], warp)
+            // Calculate memory based on tractogram files size
+            def trk_files = [trk].flatten()
+            def total_size = trk_files.collect { it.size() }.sum()
+            def mem = ((4L * 1024 * 1024 * 1024) + total_size * 7.0)
+
+            // Return with memory in meta
+            tuple(meta + [mem: mem as long], image, affine, trk, [], warp)
         }
 
     REGISTRATION_TRACTOGRAM ( ch_tractograms_to_transform )

--- a/subworkflows/nf-neuro/output_template_space/output_template_space.diff
+++ b/subworkflows/nf-neuro/output_template_space/output_template_space.diff
@@ -19,14 +19,14 @@ Changes in 'output_template_space/main.nf':
          ch_mask_files               // channel: [ val(meta), [ mask_files ] ]
          ch_labels_files             // channel: [ val(meta), [ labels_files ] ]
          ch_trk_files                // channel: [ val(meta), [ trk_files ] ]
-@@ -151,9 +153,16 @@
+@@ -151,10 +153,17 @@
          | join(REGISTRATION_ANTS.out.image)
          | join(REGISTRATION_ANTS.out.warp)
          | join(REGISTRATION_ANTS.out.affine)
 -
      WARPIMAGES ( ch_files_to_transform )
      ch_versions = ch_versions.mix(WARPIMAGES.out.versions)
-+
+ 
 +    // ** Same process for the rgb files ** //
 +    ch_rgb_to_transform = ch_rgb_files
 +        | join(REGISTRATION_ANTS.out.image)
@@ -34,10 +34,26 @@ Changes in 'output_template_space/main.nf':
 +        | join(REGISTRATION_ANTS.out.affine)
 +    WARPRGB ( ch_rgb_to_transform )
 +    ch_versions = ch_versions.mix(WARPRGB.out.versions)
- 
++
      // ** Same process for the masks ** //
      ch_masks_to_transform = ch_mask_files
-@@ -188,9 +197,9 @@
+         | join(REGISTRATION_ANTS.out.image)
+@@ -177,7 +186,13 @@
+         | join(REGISTRATION_ANTS.out.inverse_warp)
+         | join(REGISTRATION_ANTS.out.affine)
+         | map{ meta, trk, image, warp, affine ->
+-            tuple(meta, image, affine, trk, [], warp)
++            // Calculate memory based on tractogram files size
++            def trk_files = [trk].flatten()
++            def total_size = trk_files.collect { it.size() }.sum()
++            def mem = ((4L * 1024 * 1024 * 1024) + total_size * 7.0)
++
++            // Return with memory in meta
++            tuple(meta + [mem: mem as long], image, affine, trk, [], warp)
+         }
+ 
+     REGISTRATION_TRACTOGRAM ( ch_tractograms_to_transform )
+@@ -188,9 +203,9 @@
          ch_t2w_tpl                  = ch_t2w_tpl                                        // channel: [ tpl-T2w ]
          ch_registered_anat          = REGISTRATION_ANTS.out.image                       // channel: [ val(meta), [ image ] ]
          ch_warped_nifti_files       = WARPIMAGES.out.warped_image                       // channel: [ val(meta), [ warped_image ] ]


### PR DESCRIPTION
<!--
# scilus/nf-pediatric pull request

Many thanks for contributing to scilus/nf-pediatric!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/scilus/nf-pediatric/tree/master/.github/CONTRIBUTING.md)
-->

When applying a transfrom to a tractogram, the dedicated process had a fixed memory which caused issues with large tractograms (see #56). This PR introduces a dynamic resources allocation based on the size of the input tractograms. Closes #56 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/scilus/nf-pediatric/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
