### PR TITLE
FEAT: Add framewise displacement (FD) values to QC reports.

### DIFF
--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -9,6 +9,8 @@ report_section_order:
     order: -600
   "topup_qc":
     order: -625
+  "fd_qc":
+    order: -640
   "eddy_qc":
     order: -650
   "coregistration_qc":
@@ -34,6 +36,7 @@ custom_content:
   order:
     - shell_qc
     - topup_qc
+    - fd_qc
     - eddy_qc
     - anattodwi_qc
     - templatetodwi_qc
@@ -70,6 +73,28 @@ custom_data:
       eddy-current-induced displacements. Additionally, ensure that no new
       artifacts or excessive blurring are introduced in the corrected images.
     plot_type: "image"
+  fd_qc:
+    file_format: "csv"
+    section_name: "Framewise Displacement (FD) QC"
+    description: |
+      This section contains the Framewise Displacement (FD) values calculated
+      during EDDY correction. FD is a measure of head motion between successive
+      volumes in the diffusion-weighted imaging (DWI) time series. To assess
+      motion quality, examine the FD values for spikes or consistently high
+      values, which may indicate significant head movement during the scan.
+      High FD values can lead to artifacts and reduced data quality, potentially
+      impacting downstream analyses. Consider setting a threshold (e.g., 0.5 mm)
+      to identify volumes with excessive motion that may need to be excluded
+      from further analysis.
+    plot_type: "linegraph"
+    pconfig:
+      xlab: "Volume Number"
+      ylab: "Framewise Displacement (mm)"
+      title: "Framewise Displacement (FD) over DWI volumes"
+      ymax: 1
+      ymin: 0
+      y_lines:
+        - {value: 0.5, color: red, dash: dash, label: "Motion Threshold (0.5 mm)"}
   topup_qc:
     file_format: "gif"
     section_name: "Topup QC"
@@ -202,6 +227,8 @@ sp:
     fn: "*gradients_mqc.png"
   topup_qc:
     fn: "*_b0_topup_mqc.gif"
+  fd_qc:
+    fn: "*fd_mqc.csv"
   eddy_qc:
     fn: "*_dwi_eddy_mqc.gif"
   coregistration_qc:

--- a/modules/nf-core/multiqc/main.nf
+++ b/modules/nf-core/multiqc/main.nf
@@ -52,6 +52,11 @@ process MULTIQC {
         done
     fi
 
+    # Remove second column in FD from eddy if it exists
+    if ls *__dwi_eddy_restricted_movement_rms.txt 1> /dev/null 2>&1; then
+        awk '{print NR "," \$2}' *__dwi_eddy_restricted_movement_rms.txt > ${prefix}_fd_mqc.csv
+    fi
+
     multiqc \\
         --force \\
         $args \\

--- a/modules/nf-neuro/preproc/eddy/main.nf
+++ b/modules/nf-neuro/preproc/eddy/main.nf
@@ -12,6 +12,7 @@ process PREPROC_EDDY {
         tuple val(meta), path("*__dwi_eddy_corrected.bval") , emit: bval_corrected
         tuple val(meta), path("*__dwi_eddy_corrected.bvec") , emit: bvec_corrected
         tuple val(meta), path("*__b0_bet_mask.nii.gz")      , emit: b0_mask
+        tuple val(meta), path("*__dwi_eddy_restricted_movement_rms.txt"), emit: eddy_fd
         tuple val(meta), path("*__dwi_eddy_mqc.gif")        , emit: dwi_eddy_mqc, optional:true
         tuple val(meta), path("*__rev_dwi_eddy_mqc.gif")    , emit: rev_dwi_eddy_mqc, optional:true
         path "versions.yml"                                 , emit: versions
@@ -103,6 +104,9 @@ process PREPROC_EDDY {
     else
         scil_gradients_validate_correct_eddy.py dwi_eddy_corrected.eddy_rotated_bvecs \${bval} \${number_rev_dwi} ${prefix}__dwi_eddy_corrected.bvec ${prefix}__dwi_eddy_corrected.bval
     fi
+
+    # Rename framewise displacement file to include subject id
+    mv dwi_eddy_corrected.eddy_restricted_movement_rms ${prefix}__dwi_eddy_restricted_movement_rms.txt
 
     if $run_qc;
     then

--- a/subworkflows/nf-neuro/topup_eddy/main.nf
+++ b/subworkflows/nf-neuro/topup_eddy/main.nf
@@ -82,6 +82,7 @@ workflow TOPUP_EDDY {
             ch_versions = ch_versions.mix(PREPROC_EDDY.out.versions.first())
             ch_multiqc_files = ch_multiqc_files.mix(PREPROC_EDDY.out.dwi_eddy_mqc)
             ch_multiqc_files = ch_multiqc_files.mix(PREPROC_EDDY.out.rev_dwi_eddy_mqc)
+            ch_multiqc_files = ch_multiqc_files.mix(PREPROC_EDDY.out.eddy_fd)
 
             ch_dwi = PREPROC_EDDY.out.dwi_corrected
                 .join(PREPROC_EDDY.out.bval_corrected)


### PR DESCRIPTION
<!--
# scilus/nf-pediatric pull request

Many thanks for contributing to scilus/nf-pediatric!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/scilus/nf-pediatric/tree/master/.github/CONTRIBUTING.md)
-->

To improve the QC reports, this PR includes the framewise displacement metric computed by eddy to both the subject's (as a lineplot of FD over DWI volumes, as shown below) and global (as a violin plot of average FD for each subject) reports. Closes #29 

Lineplot example:
<img width="683" height="495" alt="image" src="https://github.com/user-attachments/assets/36a3ab61-dab6-494a-b29b-f94931cd0361" />


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/scilus/nf-pediatric/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
