### PR TITLE
FIX: Stride order for QC files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- Fix stride in QC sections to ensure all axis are plotted correctly ([#62](https://github.com/scilus/nf-pediatric/issues/62))
+- Fix mask resampling to force same dimension as b0 volume ([#59](https://github.com/scilus/nf-pediatric/issues/59))
 - Fix glob pattern for template to DWI registration QC file.
 - Add dynamic resource allocation for registering tractograms in output space ([#56](https://github.com/scilus/nf-pediatric/issues/56))
 - Fix RGB FA registration to template space.

--- a/modules/nf-neuro/preproc/eddy/main.nf
+++ b/modules/nf-neuro/preproc/eddy/main.nf
@@ -133,9 +133,10 @@ process PREPROC_EDDY {
 
         for image in dwi_corrected dwi \${rev_dwi}
         do
-            scil_viz_volume_screenshot.py ${prefix}__\${image}_powder_average_norm.nii.gz ${prefix}__\${image}_coronal.png \${viz_params} --slices \${coronal_dim} --axis coronal
-            scil_viz_volume_screenshot.py ${prefix}__\${image}_powder_average_norm.nii.gz ${prefix}__\${image}_axial.png \${viz_params} --slices \${axial_dim} --axis axial
-            scil_viz_volume_screenshot.py ${prefix}__\${image}_powder_average_norm.nii.gz ${prefix}__\${image}_sagittal.png \${viz_params} --slices \${sagittal_dim} --axis sagittal
+            mrconvert ${prefix}__\${image}_powder_average_norm.nii.gz ${prefix}__\${image}_powder_average_norm_viz.nii.gz -stride -1,2,3 -nthreads $task.cpus
+            scil_viz_volume_screenshot.py ${prefix}__\${image}_powder_average_norm_viz.nii.gz ${prefix}__\${image}_coronal.png \${viz_params} --slices \${coronal_dim} --axis coronal
+            scil_viz_volume_screenshot.py ${prefix}__\${image}_powder_average_norm_viz.nii.gz ${prefix}__\${image}_axial.png \${viz_params} --slices \${axial_dim} --axis axial
+            scil_viz_volume_screenshot.py ${prefix}__\${image}_powder_average_norm_viz.nii.gz ${prefix}__\${image}_sagittal.png \${viz_params} --slices \${sagittal_dim} --axis sagittal
 
             if [ \$image == "dwi_corrected" ] || [ \$image == "rev_dwi" ]
             then

--- a/modules/nf-neuro/preproc/eddy/preproc-eddy.diff
+++ b/modules/nf-neuro/preproc/eddy/preproc-eddy.diff
@@ -33,7 +33,21 @@ Changes in 'preproc/eddy/main.nf':
      if $run_qc;
      then
          extract_dim=\$(mrinfo ${dwi} -size)
-@@ -184,6 +186,7 @@
+@@ -131,9 +133,10 @@
+ 
+         for image in dwi_corrected dwi \${rev_dwi}
+         do
+-            scil_viz_volume_screenshot.py ${prefix}__\${image}_powder_average_norm.nii.gz ${prefix}__\${image}_coronal.png \${viz_params} --slices \${coronal_dim} --axis coronal
+-            scil_viz_volume_screenshot.py ${prefix}__\${image}_powder_average_norm.nii.gz ${prefix}__\${image}_axial.png \${viz_params} --slices \${axial_dim} --axis axial
+-            scil_viz_volume_screenshot.py ${prefix}__\${image}_powder_average_norm.nii.gz ${prefix}__\${image}_sagittal.png \${viz_params} --slices \${sagittal_dim} --axis sagittal
++            mrconvert ${prefix}__\${image}_powder_average_norm.nii.gz ${prefix}__\${image}_powder_average_norm_viz.nii.gz -stride -1,2,3 -nthreads $task.cpus
++            scil_viz_volume_screenshot.py ${prefix}__\${image}_powder_average_norm_viz.nii.gz ${prefix}__\${image}_coronal.png \${viz_params} --slices \${coronal_dim} --axis coronal
++            scil_viz_volume_screenshot.py ${prefix}__\${image}_powder_average_norm_viz.nii.gz ${prefix}__\${image}_axial.png \${viz_params} --slices \${axial_dim} --axis axial
++            scil_viz_volume_screenshot.py ${prefix}__\${image}_powder_average_norm_viz.nii.gz ${prefix}__\${image}_sagittal.png \${viz_params} --slices \${sagittal_dim} --axis sagittal
+ 
+             if [ \$image == "dwi_corrected" ] || [ \$image == "rev_dwi" ]
+             then
+@@ -184,6 +187,7 @@
      touch ${prefix}__dwi_eddy_corrected.bval
      touch ${prefix}__dwi_eddy_corrected.bvec
      touch ${prefix}__b0_bet_mask.nii.gz

--- a/modules/nf-neuro/preproc/topup/main.nf
+++ b/modules/nf-neuro/preproc/topup/main.nf
@@ -69,14 +69,17 @@ process PREPROC_TOPUP {
     then
         extract_dim=\$(mrinfo ${prefix}__b0_mean.nii.gz -size)
         read sagittal_dim axial_dim coronal_dim <<< "\${extract_dim}"
+        mrconvert ${prefix}__b0_mean.nii.gz ${prefix}__b0_mean_viz.nii.gz -stride -1,2,3
+        mrconvert ${prefix}__rev_b0_mean.nii.gz ${prefix}__rev_b0_mean_viz.nii.gz -stride -1,2,3
+        mrconvert ${prefix}__corrected_b0s.nii.gz ${prefix}__corrected_b0s_viz.nii.gz -stride -1,2,3
 
         # Get the middle slice
         coronal_dim=\$((\$coronal_dim / 2))
         axial_dim=\$((\$axial_dim / 2))
         sagittal_dim=\$((\$sagittal_dim / 2))
 
-        fslsplit ${prefix}__corrected_b0s.nii.gz ${prefix}__ -t
-        for image in b0_mean rev_b0_mean 0000 0001;
+        fslsplit ${prefix}__corrected_b0s_viz.nii.gz ${prefix}__ -t
+        for image in b0_mean_viz rev_b0_mean_viz 0000 0001;
         do
             viz_params="--display_slice_number --display_lr --size 256 256"
             scil_volume_math.py normalize_max ${prefix}__\${image}.nii.gz ${prefix}__\${image}_norm.nii.gz
@@ -84,7 +87,7 @@ process PREPROC_TOPUP {
             scil_viz_volume_screenshot.py ${prefix}__\${image}_norm.nii.gz ${prefix}__\${image}_axial.png \${viz_params} --slices \${axial_dim} --axis axial
             scil_viz_volume_screenshot.py ${prefix}__\${image}_norm.nii.gz ${prefix}__\${image}_sagittal.png \${viz_params} --slices \${sagittal_dim} --axis sagittal
 
-            if [ \$image == "b0_mean" ] || [ \$image == "rev_b0_mean" ];
+            if [ \$image == "b0_mean_viz" ] || [ \$image == "rev_b0_mean_viz" ];
             then
                 title="Before"
             else
@@ -99,11 +102,11 @@ process PREPROC_TOPUP {
         done
 
         convert -delay 10 -loop 0 -morph 10 \
-                ${prefix}__b0_mean.png ${prefix}__0000.png ${prefix}__b0_mean.png \
+                ${prefix}__b0_mean_viz.png ${prefix}__0000.png ${prefix}__b0_mean_viz.png \
                 ${prefix}__b0_topup_mqc.gif
 
         convert  -delay 10 -loop 0 -morph 10 \
-                ${prefix}__rev_b0_mean.png ${prefix}__0001.png ${prefix}__rev_b0_mean.png \
+                ${prefix}__rev_b0_mean_viz.png ${prefix}__0001.png ${prefix}__rev_b0_mean_viz.png \
                 ${prefix}__rev_b0_topup_mqc.gif
     fi
 

--- a/modules/nf-neuro/preproc/topup/main.nf
+++ b/modules/nf-neuro/preproc/topup/main.nf
@@ -68,7 +68,7 @@ process PREPROC_TOPUP {
     if $run_qc;
     then
         extract_dim=\$(mrinfo ${prefix}__b0_mean.nii.gz -size)
-        read sagittal_dim axial_dim coronal_dim <<< "\${extract_dim}"
+        read sagittal_dim coronal_dim axial_dim <<< "\${extract_dim}"
         mrconvert ${prefix}__b0_mean.nii.gz ${prefix}__b0_mean_viz.nii.gz -stride -1,2,3
         mrconvert ${prefix}__rev_b0_mean.nii.gz ${prefix}__rev_b0_mean_viz.nii.gz -stride -1,2,3
         mrconvert ${prefix}__corrected_b0s.nii.gz ${prefix}__corrected_b0s_viz.nii.gz -stride -1,2,3

--- a/modules/nf-neuro/preproc/topup/preproc-topup.diff
+++ b/modules/nf-neuro/preproc/topup/preproc-topup.diff
@@ -15,10 +15,12 @@ Changes in 'preproc/topup/main.nf':
  
      input:
          tuple val(meta), path(dwi), path(bval), path(bvec), path(b0), path(rev_dwi), path(rev_bval), path(rev_bvec), path(rev_b0)
-@@ -71,14 +69,17 @@
+@@ -70,15 +68,18 @@
+     if $run_qc;
      then
          extract_dim=\$(mrinfo ${prefix}__b0_mean.nii.gz -size)
-         read sagittal_dim axial_dim coronal_dim <<< "\${extract_dim}"
+-        read sagittal_dim axial_dim coronal_dim <<< "\${extract_dim}"
++        read sagittal_dim coronal_dim axial_dim <<< "\${extract_dim}"
 +        mrconvert ${prefix}__b0_mean.nii.gz ${prefix}__b0_mean_viz.nii.gz -stride -1,2,3
 +        mrconvert ${prefix}__rev_b0_mean.nii.gz ${prefix}__rev_b0_mean_viz.nii.gz -stride -1,2,3
 +        mrconvert ${prefix}__corrected_b0s.nii.gz ${prefix}__corrected_b0s_viz.nii.gz -stride -1,2,3

--- a/modules/nf-neuro/preproc/topup/preproc-topup.diff
+++ b/modules/nf-neuro/preproc/topup/preproc-topup.diff
@@ -15,6 +15,49 @@ Changes in 'preproc/topup/main.nf':
  
      input:
          tuple val(meta), path(dwi), path(bval), path(bvec), path(b0), path(rev_dwi), path(rev_bval), path(rev_bvec), path(rev_b0)
+@@ -71,14 +69,17 @@
+     then
+         extract_dim=\$(mrinfo ${prefix}__b0_mean.nii.gz -size)
+         read sagittal_dim axial_dim coronal_dim <<< "\${extract_dim}"
++        mrconvert ${prefix}__b0_mean.nii.gz ${prefix}__b0_mean_viz.nii.gz -stride -1,2,3
++        mrconvert ${prefix}__rev_b0_mean.nii.gz ${prefix}__rev_b0_mean_viz.nii.gz -stride -1,2,3
++        mrconvert ${prefix}__corrected_b0s.nii.gz ${prefix}__corrected_b0s_viz.nii.gz -stride -1,2,3
+ 
+         # Get the middle slice
+         coronal_dim=\$((\$coronal_dim / 2))
+         axial_dim=\$((\$axial_dim / 2))
+         sagittal_dim=\$((\$sagittal_dim / 2))
+ 
+-        fslsplit ${prefix}__corrected_b0s.nii.gz ${prefix}__ -t
+-        for image in b0_mean rev_b0_mean 0000 0001;
++        fslsplit ${prefix}__corrected_b0s_viz.nii.gz ${prefix}__ -t
++        for image in b0_mean_viz rev_b0_mean_viz 0000 0001;
+         do
+             viz_params="--display_slice_number --display_lr --size 256 256"
+             scil_volume_math.py normalize_max ${prefix}__\${image}.nii.gz ${prefix}__\${image}_norm.nii.gz
+@@ -86,7 +87,7 @@
+             scil_viz_volume_screenshot.py ${prefix}__\${image}_norm.nii.gz ${prefix}__\${image}_axial.png \${viz_params} --slices \${axial_dim} --axis axial
+             scil_viz_volume_screenshot.py ${prefix}__\${image}_norm.nii.gz ${prefix}__\${image}_sagittal.png \${viz_params} --slices \${sagittal_dim} --axis sagittal
+ 
+-            if [ \$image == "b0_mean" ] || [ \$image == "rev_b0_mean" ];
++            if [ \$image == "b0_mean_viz" ] || [ \$image == "rev_b0_mean_viz" ];
+             then
+                 title="Before"
+             else
+@@ -101,11 +102,11 @@
+         done
+ 
+         convert -delay 10 -loop 0 -morph 10 \
+-                ${prefix}__b0_mean.png ${prefix}__0000.png ${prefix}__b0_mean.png \
++                ${prefix}__b0_mean_viz.png ${prefix}__0000.png ${prefix}__b0_mean_viz.png \
+                 ${prefix}__b0_topup_mqc.gif
+ 
+         convert  -delay 10 -loop 0 -morph 10 \
+-                ${prefix}__rev_b0_mean.png ${prefix}__0001.png ${prefix}__rev_b0_mean.png \
++                ${prefix}__rev_b0_mean_viz.png ${prefix}__0001.png ${prefix}__rev_b0_mean_viz.png \
+                 ${prefix}__rev_b0_topup_mqc.gif
+     fi
+ 
 
 'modules/nf-neuro/preproc/topup/tests/main.nf.test.snap' is unchanged
 'modules/nf-neuro/preproc/topup/tests/tags.yml' is unchanged

--- a/modules/nf-neuro/reconst/dtimetrics/main.nf
+++ b/modules/nf-neuro/reconst/dtimetrics/main.nf
@@ -119,10 +119,11 @@ process RECONST_DTIMETRICS {
 
             image=\${image/${prefix}__/}
             image=\${image/.nii.gz/}
+            mrconvert ${prefix}__\${image}.nii.gz ${prefix}__\${image}_viz.nii.gz -stride -1,2,3 -nthreads $task.cpus
             viz_params="--display_slice_number --display_lr --size 256 256"
-            scil_viz_volume_screenshot.py ${prefix}__\${image}.nii.gz ${prefix}__\${image}_coronal.png \${viz_params} --slices \${coronal_dim} --axis coronal
-            scil_viz_volume_screenshot.py ${prefix}__\${image}.nii.gz ${prefix}__\${image}_axial.png \${viz_params} --slices \${axial_dim} --axis axial
-            scil_viz_volume_screenshot.py ${prefix}__\${image}.nii.gz ${prefix}__\${image}_sagittal.png \${viz_params} --slices \${sagittal_dim} --axis sagittal
+            scil_viz_volume_screenshot.py ${prefix}__\${image}_viz.nii.gz ${prefix}__\${image}_coronal.png \${viz_params} --slices \${coronal_dim} --axis coronal
+            scil_viz_volume_screenshot.py ${prefix}__\${image}_viz.nii.gz ${prefix}__\${image}_axial.png \${viz_params} --slices \${axial_dim} --axis axial
+            scil_viz_volume_screenshot.py ${prefix}__\${image}_viz.nii.gz ${prefix}__\${image}_sagittal.png \${viz_params} --slices \${sagittal_dim} --axis sagittal
 
             convert +append ${prefix}__\${image}_coronal_slice_\${coronal_dim}.png \
                     ${prefix}__\${image}_axial_slice_\${axial_dim}.png  \

--- a/modules/nf-neuro/reconst/dtimetrics/reconst-dtimetrics.diff
+++ b/modules/nf-neuro/reconst/dtimetrics/reconst-dtimetrics.diff
@@ -15,6 +15,21 @@ Changes in 'reconst/dtimetrics/main.nf':
  
      input:
          tuple val(meta), path(dwi), path(bval), path(bvec), path(b0mask)
+@@ -121,10 +119,11 @@
+ 
+             image=\${image/${prefix}__/}
+             image=\${image/.nii.gz/}
++            mrconvert ${prefix}__\${image}.nii.gz ${prefix}__\${image}_viz.nii.gz -stride -1,2,3 -nthreads $task.cpus
+             viz_params="--display_slice_number --display_lr --size 256 256"
+-            scil_viz_volume_screenshot.py ${prefix}__\${image}.nii.gz ${prefix}__\${image}_coronal.png \${viz_params} --slices \${coronal_dim} --axis coronal
+-            scil_viz_volume_screenshot.py ${prefix}__\${image}.nii.gz ${prefix}__\${image}_axial.png \${viz_params} --slices \${axial_dim} --axis axial
+-            scil_viz_volume_screenshot.py ${prefix}__\${image}.nii.gz ${prefix}__\${image}_sagittal.png \${viz_params} --slices \${sagittal_dim} --axis sagittal
++            scil_viz_volume_screenshot.py ${prefix}__\${image}_viz.nii.gz ${prefix}__\${image}_coronal.png \${viz_params} --slices \${coronal_dim} --axis coronal
++            scil_viz_volume_screenshot.py ${prefix}__\${image}_viz.nii.gz ${prefix}__\${image}_axial.png \${viz_params} --slices \${axial_dim} --axis axial
++            scil_viz_volume_screenshot.py ${prefix}__\${image}_viz.nii.gz ${prefix}__\${image}_sagittal.png \${viz_params} --slices \${sagittal_dim} --axis sagittal
+ 
+             convert +append ${prefix}__\${image}_coronal_slice_\${coronal_dim}.png \
+                     ${prefix}__\${image}_axial_slice_\${axial_dim}.png  \
 
 'modules/nf-neuro/reconst/dtimetrics/tests/main.nf.test.snap' is unchanged
 'modules/nf-neuro/reconst/dtimetrics/tests/nextflow_light.config' is unchanged

--- a/modules/nf-neuro/registration/anattodwi/main.nf
+++ b/modules/nf-neuro/registration/anattodwi/main.nf
@@ -74,11 +74,12 @@ process REGISTRATION_ANATTODWI {
         # Iterate over images.
         for image in ${suffix}_warped reference;
         do
-            scil_viz_volume_screenshot.py *\${image}.nii.gz \${image}_coronal.png \
+            mrconvert *\${image}.nii.gz *\${image}_viz.nii.gz -stride -1,2,3 -nthreads $task.cpus
+            scil_viz_volume_screenshot.py *\${image}_viz.nii.gz \${image}_coronal.png \
                 --slices \$coronal_mid --axis coronal \$viz_params
-            scil_viz_volume_screenshot.py *\${image}.nii.gz \${image}_sagittal.png \
+            scil_viz_volume_screenshot.py *\${image}_viz.nii.gz \${image}_sagittal.png \
                 --slices \$sagittal_mid --axis sagittal \$viz_params
-            scil_viz_volume_screenshot.py *\${image}.nii.gz \${image}_axial.png \
+            scil_viz_volume_screenshot.py *\${image}_viz.nii.gz \${image}_axial.png \
                 --slices \$axial_mid --axis axial \$viz_params
 
             if [ \$image != reference ];

--- a/modules/nf-neuro/registration/anattodwi/registration-anattodwi.diff
+++ b/modules/nf-neuro/registration/anattodwi/registration-anattodwi.diff
@@ -63,7 +63,7 @@ Changes in 'registration/anattodwi/main.nf':
          read sagittal_dim coronal_dim axial_dim <<< "\${dim}"
  
          # Get middle slices.
-@@ -70,8 +70,9 @@
+@@ -70,21 +70,23 @@
          # Set viz params.
          viz_params="--display_slice_number --display_lr --size 256 256"
  
@@ -72,10 +72,15 @@ Changes in 'registration/anattodwi/main.nf':
 -        for image in t1_warped b0;
 +        for image in ${suffix}_warped reference;
          do
-             scil_viz_volume_screenshot.py *\${image}.nii.gz \${image}_coronal.png \
+-            scil_viz_volume_screenshot.py *\${image}.nii.gz \${image}_coronal.png \
++            mrconvert *\${image}.nii.gz *\${image}_viz.nii.gz -stride -1,2,3 -nthreads $task.cpus
++            scil_viz_volume_screenshot.py *\${image}_viz.nii.gz \${image}_coronal.png \
                  --slices \$coronal_mid --axis coronal \$viz_params
-@@ -80,11 +81,11 @@
-             scil_viz_volume_screenshot.py *\${image}.nii.gz \${image}_axial.png \
+-            scil_viz_volume_screenshot.py *\${image}.nii.gz \${image}_sagittal.png \
++            scil_viz_volume_screenshot.py *\${image}_viz.nii.gz \${image}_sagittal.png \
+                 --slices \$sagittal_mid --axis sagittal \$viz_params
+-            scil_viz_volume_screenshot.py *\${image}.nii.gz \${image}_axial.png \
++            scil_viz_volume_screenshot.py *\${image}_viz.nii.gz \${image}_axial.png \
                  --slices \$axial_mid --axis axial \$viz_params
  
 -            if [ \$image != b0 ];
@@ -89,7 +94,7 @@ Changes in 'registration/anattodwi/main.nf':
              fi
  
              convert +append \${image}_coronal*.png \${image}_axial*.png \
-@@ -98,11 +99,11 @@
+@@ -98,11 +100,11 @@
  
          # Create GIF.
          convert -delay 10 -loop 0 -morph 10 \
@@ -104,7 +109,7 @@ Changes in 'registration/anattodwi/main.nf':
      fi
  
      cat <<-END_VERSIONS > versions.yml
-@@ -115,15 +116,17 @@
+@@ -115,15 +117,17 @@
  
      stub:
      def prefix = task.ext.prefix ?: "${meta.id}"

--- a/modules/nf-neuro/registration/ants/main.nf
+++ b/modules/nf-neuro/registration/ants/main.nf
@@ -80,11 +80,12 @@ process REGISTRATION_ANTS {
         # Iterate over images.
         for image in fixedimage warped;
         do
-            scil_viz_volume_screenshot.py *\${image}.nii.gz \${image}_coronal.png \
+            mrconvert *\${image}.nii.gz *\${image}_viz.nii.gz -stride -1,2,3 -nthreads $task.cpus
+            scil_viz_volume_screenshot.py *\${image}_viz.nii.gz \${image}_coronal.png \
                 --slices \$coronal_dim --axis coronal \$viz_params
-            scil_viz_volume_screenshot.py *\${image}.nii.gz \${image}_sagittal.png \
+            scil_viz_volume_screenshot.py *\${image}_viz.nii.gz \${image}_sagittal.png \
                 --slices \$sagittal_dim --axis sagittal \$viz_params
-            scil_viz_volume_screenshot.py *\${image}.nii.gz \${image}_axial.png \
+            scil_viz_volume_screenshot.py *\${image}_viz.nii.gz \${image}_axial.png \
                 --slices \$axial_dim --axis axial \$viz_params
             if [ \$image != fixedimage ];
             then

--- a/modules/nf-neuro/registration/ants/registration-ants.diff
+++ b/modules/nf-neuro/registration/ants/registration-ants.diff
@@ -39,7 +39,23 @@ Changes in 'registration/ants/main.nf':
      mv output0GenericAffine.mat ${prefix}__output1GenericAffine.mat
  
      if [ $transform != "t" ] && [ $transform != "r" ] && [ $transform != "a" ];
-@@ -119,9 +118,10 @@
+@@ -81,11 +80,12 @@
+         # Iterate over images.
+         for image in fixedimage warped;
+         do
+-            scil_viz_volume_screenshot.py *\${image}.nii.gz \${image}_coronal.png \
++            mrconvert *\${image}.nii.gz *\${image}_viz.nii.gz -stride -1,2,3 -nthreads $task.cpus
++            scil_viz_volume_screenshot.py *\${image}_viz.nii.gz \${image}_coronal.png \
+                 --slices \$coronal_dim --axis coronal \$viz_params
+-            scil_viz_volume_screenshot.py *\${image}.nii.gz \${image}_sagittal.png \
++            scil_viz_volume_screenshot.py *\${image}_viz.nii.gz \${image}_sagittal.png \
+                 --slices \$sagittal_dim --axis sagittal \$viz_params
+-            scil_viz_volume_screenshot.py *\${image}.nii.gz \${image}_axial.png \
++            scil_viz_volume_screenshot.py *\${image}_viz.nii.gz \${image}_axial.png \
+                 --slices \$axial_dim --axis axial \$viz_params
+             if [ \$image != fixedimage ];
+             then
+@@ -119,9 +119,10 @@
      stub:
      def args = task.ext.args ?: ''
      def prefix = task.ext.prefix ?: "${meta.id}"

--- a/modules/nf-neuro/registration/antsapplytransforms/main.nf
+++ b/modules/nf-neuro/registration/antsapplytransforms/main.nf
@@ -64,11 +64,12 @@ process REGISTRATION_ANTSAPPLYTRANSFORMS {
             # Iterate over images.
             for image in reference \${bname}${suffix};
             do
-                scil_viz_volume_screenshot.py *\${image}.nii.gz \${image}_coronal.png \
+                mrconvert *\${image}.nii.gz *\${image}_viz.nii.gz -stride -1,2,3 -nthreads $task.cpus
+                scil_viz_volume_screenshot.py *\${image}_viz.nii.gz \${image}_coronal.png \
                     --slices \$coronal_dim --axis coronal \$viz_params
-                scil_viz_volume_screenshot.py *\${image}.nii.gz \${image}_sagittal.png \
+                scil_viz_volume_screenshot.py *\${image}_viz.nii.gz \${image}_sagittal.png \
                     --slices \$sagittal_dim --axis sagittal \$viz_params
-                scil_viz_volume_screenshot.py *\${image}.nii.gz \${image}_axial.png \
+                scil_viz_volume_screenshot.py *\${image}_viz.nii.gz \${image}_axial.png \
                     --slices \$axial_dim --axis axial \$viz_params
                 if [ \$image != reference ];
                 then

--- a/modules/nf-neuro/registration/antsapplytransforms/registration-antsapplytransforms.diff
+++ b/modules/nf-neuro/registration/antsapplytransforms/registration-antsapplytransforms.diff
@@ -15,6 +15,22 @@ Changes in 'registration/antsapplytransforms/main.nf':
  
      input:
      tuple val(meta), path(image), path(reference), path(warp), path(affine)
+@@ -66,11 +64,12 @@
+             # Iterate over images.
+             for image in reference \${bname}${suffix};
+             do
+-                scil_viz_volume_screenshot.py *\${image}.nii.gz \${image}_coronal.png \
++                mrconvert *\${image}.nii.gz *\${image}_viz.nii.gz -stride -1,2,3 -nthreads $task.cpus
++                scil_viz_volume_screenshot.py *\${image}_viz.nii.gz \${image}_coronal.png \
+                     --slices \$coronal_dim --axis coronal \$viz_params
+-                scil_viz_volume_screenshot.py *\${image}.nii.gz \${image}_sagittal.png \
++                scil_viz_volume_screenshot.py *\${image}_viz.nii.gz \${image}_sagittal.png \
+                     --slices \$sagittal_dim --axis sagittal \$viz_params
+-                scil_viz_volume_screenshot.py *\${image}.nii.gz \${image}_axial.png \
++                scil_viz_volume_screenshot.py *\${image}_viz.nii.gz \${image}_axial.png \
+                     --slices \$axial_dim --axis axial \$viz_params
+                 if [ \$image != reference ];
+                 then
 
 'modules/nf-neuro/registration/antsapplytransforms/tests/main.nf.test.snap' is unchanged
 'modules/nf-neuro/registration/antsapplytransforms/tests/tags.yml' is unchanged

--- a/nextflow.config
+++ b/nextflow.config
@@ -428,6 +428,7 @@ profiles {
     test_full { includeConfig 'conf/test_full.config' }
     slurm {
         process {
+            errorStrategy = { task.exitStatus in ((130..145) + 104 + 175) ? 'retry' : 'ignore' }
             maxRetries          = 1
             cache               = "lenient"
             afterScript         = "sleep 60"


### PR DESCRIPTION
<!--
# scilus/nf-pediatric pull request

Many thanks for contributing to scilus/nf-pediatric!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/scilus/nf-pediatric/tree/master/.github/CONTRIBUTING.md)
-->

We previously had issues in the QC section when the number of slices in each axis were unbalanced and stride was not -1,2,3. This PR add a converting step into stride -1,2,3 before plotting. This is a temporary fix for the first release, final fixes will be made in nf-neuro. Closes #62 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/scilus/nf-pediatric/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
