### PR TITLE
FIX: name collision in concatenate/stats module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- Fix name collision when multiple sessions in concatenate stats module.
 - Fix stride in QC sections to ensure all axis are plotted correctly ([#62](https://github.com/scilus/nf-pediatric/issues/62))
 - Fix mask resampling to force same dimension as b0 volume ([#59](https://github.com/scilus/nf-pediatric/issues/59))
 - Fix glob pattern for template to DWI registration QC file.

--- a/modules/local/atlases/brainnetomechild.nf
+++ b/modules/local/atlases/brainnetomechild.nf
@@ -22,7 +22,7 @@ process ATLASES_BRAINNETOMECHILD {
 
     script:
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def ses = meta.ses ? "_${meta.ses}" : ""
+    def ses = meta.session ? "_${meta.session}" : ""
 
     """
     # Exporting the FS license and setting up the environment
@@ -211,7 +211,7 @@ process ATLASES_BRAINNETOMECHILD {
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def ses = meta.ses ? "_${meta.ses}" : ""
+    def ses = meta.session ? "_${meta.session}" : ""
 
     """
     touch ${prefix}__brainnetome_child_v1.nii.gz

--- a/modules/local/atlases/brainnetomechild.nf
+++ b/modules/local/atlases/brainnetomechild.nf
@@ -22,6 +22,7 @@ process ATLASES_BRAINNETOMECHILD {
 
     script:
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def ses = meta.ses ? "_${meta.ses}" : ""
 
     """
     # Exporting the FS license and setting up the environment
@@ -94,12 +95,12 @@ process ATLASES_BRAINNETOMECHILD {
     mris_anatomical_stats -mgz -cortex \${FS_ID_FOLDER}/label/rh.cortex.label -f \${FS_ID_FOLDER}/stats/rh.BN_Child.stats -b -a \${FS_ID_FOLDER}/label/rh.BN_Child.annot -c BN_child_atlas/tmp/atlas_brainnetome_child_v1_LUT.txt \${SUBJID} rh white >> logfile.txt &>> logfile.txt
 
     # Extracting the stats into a tsv file.
-    aparcstats2table --subjects \${SUBJID} --hemi=lh -m volume -p BN_Child --tablefile=\${OUT_DIR}/\${SUBJID}__volume_lh.BN_Child.tsv >> logfile.txt &>> logfile.txt
-    aparcstats2table --subjects \${SUBJID} --hemi=rh -m volume -p BN_Child --tablefile=\${OUT_DIR}/\${SUBJID}__volume_rh.BN_Child.tsv >> logfile.txt &>> logfile.txt
-    aparcstats2table --subjects \${SUBJID} --hemi=lh -m thickness -p BN_Child --tablefile=\${OUT_DIR}/\${SUBJID}__thickness_lh.BN_Child.tsv >> logfile.txt &>> logfile.txt
-    aparcstats2table --subjects \${SUBJID} --hemi=rh -m thickness -p BN_Child --tablefile=\${OUT_DIR}/\${SUBJID}__thickness_rh.BN_Child.tsv >> logfile.txt &>> logfile.txt
-    aparcstats2table --subjects \${SUBJID} --hemi=lh -m area -p BN_Child --tablefile=\${OUT_DIR}/\${SUBJID}__area_lh.BN_Child.tsv >> logfile.txt &>> logfile.txt
-    aparcstats2table --subjects \${SUBJID} --hemi=rh -m area -p BN_Child --tablefile=\${OUT_DIR}/\${SUBJID}__area_rh.BN_Child.tsv >> logfile.txt &>> logfile.txt
+    aparcstats2table --subjects \${SUBJID} --hemi=lh -m volume -p BN_Child --tablefile=\${OUT_DIR}/\${SUBJID}${ses}__volume_lh.BN_Child.tsv >> logfile.txt &>> logfile.txt
+    aparcstats2table --subjects \${SUBJID} --hemi=rh -m volume -p BN_Child --tablefile=\${OUT_DIR}/\${SUBJID}${ses}__volume_rh.BN_Child.tsv >> logfile.txt &>> logfile.txt
+    aparcstats2table --subjects \${SUBJID} --hemi=lh -m thickness -p BN_Child --tablefile=\${OUT_DIR}/\${SUBJID}${ses}__thickness_lh.BN_Child.tsv >> logfile.txt &>> logfile.txt
+    aparcstats2table --subjects \${SUBJID} --hemi=rh -m thickness -p BN_Child --tablefile=\${OUT_DIR}/\${SUBJID}${ses}__thickness_rh.BN_Child.tsv >> logfile.txt &>> logfile.txt
+    aparcstats2table --subjects \${SUBJID} --hemi=lh -m area -p BN_Child --tablefile=\${OUT_DIR}/\${SUBJID}${ses}__area_lh.BN_Child.tsv >> logfile.txt &>> logfile.txt
+    aparcstats2table --subjects \${SUBJID} --hemi=rh -m area -p BN_Child --tablefile=\${OUT_DIR}/\${SUBJID}${ses}__area_rh.BN_Child.tsv >> logfile.txt &>> logfile.txt
 
     # ==================================================================================
     # Create the Brainnetomme subcortical parcellation from Freesurfer data
@@ -177,7 +178,7 @@ process ATLASES_BRAINNETOMECHILD {
         --o \${FS_ID_FOLDER}/stats/subcortical.BN_Child.stats --pv \${FS_ID_FOLDER}/mri/synthSR.norm.mgz \
         --id 189 190 191 192 193 194 195 196 197 198 199 200 201 202 203 204 205 206 207 208 209 210 211 212 213 214 215 216 217 218 219 220 221 222 223 224 225 226 227
     asegstats2table --subjects \${SUBJID} --meas=volume \
-        --tablefile=\${OUT_DIR}/\${SUBJID}__volume_BN_Child_subcortical.tsv --all-segs --stats=subcortical.BN_Child.stats
+        --tablefile=\${OUT_DIR}/\${SUBJID}${ses}__volume_BN_Child_subcortical.tsv --all-segs --stats=subcortical.BN_Child.stats
 
     # Dilating the atlas
     mri_convert \${FS_ID_FOLDER}/mri/brainmask.mgz BN_child_atlas/brain_mask.nii.gz
@@ -210,19 +211,20 @@ process ATLASES_BRAINNETOMECHILD {
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def ses = meta.ses ? "_${meta.ses}" : ""
 
     """
     touch ${prefix}__brainnetome_child_v1.nii.gz
     touch ${prefix}__brainnetome_child_v1_dilated.nii.gz
     touch ${prefix}__brainnetome_child_v1.txt
     touch ${prefix}__brainnetome_child_v1.json
-    touch ${prefix}__volume_BN_Child_subcortical.tsv
-    touch ${prefix}__volume_lh.BN_Child.tsv
-    touch ${prefix}__volume_rh.BN_Child.tsv
-    touch ${prefix}__area_lh.BN_Child.tsv
-    touch ${prefix}__area_rh.BN_Child.tsv
-    touch ${prefix}__thickness_lh.BN_Child.tsv
-    touch ${prefix}__thickness_rh.BN_Child.tsv
+    touch ${prefix}${ses}__volume_BN_Child_subcortical.tsv
+    touch ${prefix}${ses}__volume_lh.BN_Child.tsv
+    touch ${prefix}${ses}__volume_rh.BN_Child.tsv
+    touch ${prefix}${ses}__area_lh.BN_Child.tsv
+    touch ${prefix}${ses}__area_rh.BN_Child.tsv
+    touch ${prefix}${ses}__thickness_lh.BN_Child.tsv
+    touch ${prefix}${ses}__thickness_rh.BN_Child.tsv
     touch lh.BN_Child.annot
     touch rh.BN_Child.annot
     touch lh.BN_Child.stats

--- a/modules/local/atlases/formatlabels.nf
+++ b/modules/local/atlases/formatlabels.nf
@@ -17,7 +17,7 @@ process ATLASES_FORMATLABELS {
 
     script:
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def ses = meta.ses ? "_${meta.ses}" : ""
+    def ses = meta.session ? "_${meta.session}" : ""
 
     """
     # Exporting the FS license and setting up the environment
@@ -86,7 +86,7 @@ process ATLASES_FORMATLABELS {
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def ses = meta.ses ? "_${meta.ses}" : ""
+    def ses = meta.session ? "_${meta.session}" : ""
     """
     export PYTHONPATH=/opt/freesurfer/python/packages:\$PYTHONPATH
 

--- a/modules/local/atlases/formatlabels.nf
+++ b/modules/local/atlases/formatlabels.nf
@@ -17,6 +17,7 @@ process ATLASES_FORMATLABELS {
 
     script:
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def ses = meta.ses ? "_${meta.ses}" : ""
 
     """
     # Exporting the FS license and setting up the environment
@@ -26,53 +27,53 @@ process ATLASES_FORMATLABELS {
     mv $folder ${prefix}
 
     # Creating the label file.
-    scil_remove_labels.py ${prefix}/mri/aparc+aseg.nii.gz ${prefix}__labels.nii.gz \
+    scil_remove_labels.py ${prefix}/mri/aparc+aseg.nii.gz ${prefix}${ses}__labels.nii.gz \
         -i 4 24 43 159 160 161 162 253 -f
 
     # By default, labels are in range 1000-2000, let's reformat them.
     scil_combine_labels.py \
-        --volume_ids ${prefix}__labels.nii.gz 1001 2001 1002 2002 1003 2003 \
+        --volume_ids ${prefix}${ses}__labels.nii.gz 1001 2001 1002 2002 1003 2003 \
         1004 2004 1005 2005 1006 2006 1007 2007 1008 2008 1009 2009 1010 2010 \
         1011 2011 1012 2012 1013 2013 1014 2014 1015 2015 1016 2016 1017 2017 \
         1018 2018 1019 2019 1020 2020 1021 2021 1022 2022 1023 2023 1024 2024 \
         1025 2025 1026 2026 1027 2027 1028 2028 1029 2029 1030 2030 1031 2031 \
         1032 2032 1033 2033 1034 2034 1035 2035 18 54 17 53 11 50 13 52 12 51 \
         9 48 16 8 47 \
-        --unique ${prefix}__labels.nii.gz -f
+        --unique ${prefix}${ses}__labels.nii.gz -f
 
     # Extracting subcortical volume.
     asegstats2table --subjects ${prefix} --meas volume \
-        --tablefile ${prefix}__volume_aseg_subcortical.tsv --no-vol-extras
+        --tablefile ${prefix}${ses}__volume_aseg_subcortical.tsv --no-vol-extras
 
     # Extracting cortical statistics.
     python3 $utils/convert_fs_stats.py \
         -i ${prefix}/stats/lh.aparc.stats \
-        -o ${prefix}__volume_lh.aparc.tsv \
+        -o ${prefix}${ses}__volume_lh.aparc.tsv \
         -m GrayVol \
         -s ${prefix}
     python3 $utils/convert_fs_stats.py \
         -i ${prefix}/stats/rh.aparc.stats \
-        -o ${prefix}__volume_rh.aparc.tsv \
+        -o ${prefix}${ses}__volume_rh.aparc.tsv \
         -m GrayVol \
         -s ${prefix}
     python3 $utils/convert_fs_stats.py \
         -i ${prefix}/stats/lh.aparc.stats \
-        -o ${prefix}__area_lh.aparc.tsv \
+        -o ${prefix}${ses}__area_lh.aparc.tsv \
         -m SurfArea \
         -s ${prefix}
     python3 $utils/convert_fs_stats.py \
         -i ${prefix}/stats/rh.aparc.stats \
-        -o ${prefix}__area_rh.aparc.tsv \
+        -o ${prefix}${ses}__area_rh.aparc.tsv \
         -m SurfArea \
         -s ${prefix}
     python3 $utils/convert_fs_stats.py \
         -i ${prefix}/stats/lh.aparc.stats \
-        -o ${prefix}__thickness_lh.aparc.tsv \
+        -o ${prefix}${ses}__thickness_lh.aparc.tsv \
         -m ThickAvg \
         -s ${prefix}
     python3 $utils/convert_fs_stats.py \
         -i ${prefix}/stats/rh.aparc.stats \
-        -o ${prefix}__thickness_rh.aparc.tsv \
+        -o ${prefix}${ses}__thickness_rh.aparc.tsv \
         -m ThickAvg \
         -s ${prefix}
 
@@ -85,17 +86,18 @@ process ATLASES_FORMATLABELS {
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def ses = meta.ses ? "_${meta.ses}" : ""
     """
     export PYTHONPATH=/opt/freesurfer/python/packages:\$PYTHONPATH
 
-    touch ${prefix}__labels.nii.gz
-    touch ${prefix}__volume_aseg_subcortical.tsv
-    touch ${prefix}__volume_lh.aparc.tsv
-    touch ${prefix}__volume_rh.aparc.tsv
-    touch ${prefix}__area_lh.aparc.tsv
-    touch ${prefix}__area_rh.aparc.tsv
-    touch ${prefix}__thickness_lh.aparc.tsv
-    touch ${prefix}__thickness_rh.aparc.tsv
+    touch ${prefix}${ses}__labels.nii.gz
+    touch ${prefix}${ses}__volume_aseg_subcortical.tsv
+    touch ${prefix}${ses}__volume_lh.aparc.tsv
+    touch ${prefix}${ses}__volume_rh.aparc.tsv
+    touch ${prefix}${ses}__area_lh.aparc.tsv
+    touch ${prefix}${ses}__area_rh.aparc.tsv
+    touch ${prefix}${ses}__thickness_lh.aparc.tsv
+    touch ${prefix}${ses}__thickness_rh.aparc.tsv
 
     scil_remove_labels.py -h
     scil_combine_labels.py -h


### PR DESCRIPTION
<!--
# scilus/nf-pediatric pull request

Many thanks for contributing to scilus/nf-pediatric!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/scilus/nf-pediatric/tree/master/.github/CONTRIBUTING.md)
-->

When multiple sessions, stats files end up all having the same filename, which causes a collision when concatenating the stats into a single file. This PR simply adds the session as a string in the filename.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/scilus/nf-pediatric/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
